### PR TITLE
Fastmail now supports U2F,

### DIFF
--- a/_data/devices/email.yml
+++ b/_data/devices/email.yml
@@ -10,7 +10,8 @@ websites:
       img: fastmail.png
       tfa: Yes
       otp: Yes
-      doc: https://www.fastmail.fm/help/features_alternative_logins.html
+      u2f: Yes
+      doc: https://www.fastmail.com/help/account/2fa.html
 
     - name: Gmail
       url: https://gmail.com


### PR DESCRIPTION
Added U2F support for Fastmail, and also edited broken link to Fastmail 2FA information
